### PR TITLE
feat: :sparkles: Add humidity data to the table

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
           <tr>
             <th>Time</th>
             <th>Temperature</th>
+            <th>Humidity</th>
           </tr>
         </thead>
         <tbody></tbody>

--- a/index.js
+++ b/index.js
@@ -1,13 +1,15 @@
 document.addEventListener('DOMContentLoaded', () => {
-  fetch('https://api.open-meteo.com/v1/forecast?latitude=24.8&longitude=121.0&hourly=temperature_2m')
+  fetch('https://api.open-meteo.com/v1/forecast?latitude=24.8&longitude=121.0&hourly=temperature_2m,relativehumidity_2m')
     .then(response => response.json())
     .then(data => {
       const temperatures = data.hourly.temperature_2m;
+      const humidities = data.hourly.relativehumidity_2m;
       const times = data.hourly.time;
 
       const result = times.map((time, index) => ({
         time: moment(time).format('MMM Do YYYY, h:mm A'),
-        temperature_2m: temperatures[index]
+        temperature_2m: temperatures[index],
+        humidity_2m: humidities[index]
       }));
 
       const tableBody = document.querySelector('#temperature-table tbody');
@@ -18,12 +20,15 @@ document.addEventListener('DOMContentLoaded', () => {
         const row = document.createElement('tr');
         const timeCell = document.createElement('td');
         const temperatureCell = document.createElement('td');
+        const humidityCell = document.createElement('td');
 
         timeCell.textContent = item.time;
         temperatureCell.textContent = item.temperature_2m;
+        humidityCell.textContent = item.humidity_2m;
 
         row.appendChild(timeCell);
         row.appendChild(temperatureCell);
+        row.appendChild(humidityCell);
         tableBody.appendChild(row);
       });
     })


### PR DESCRIPTION
# Purpose

The original table has only `time` and `format`. This PR aims to add `humidity` to the table.

# Solution

- We modify the `params` of the api request to [Open-Meteo](https://open-meteo.com/) in order to retrieve the humidity data as well.
- Then, we add the `humidity` column to our table and display the retrieved humidity data in the column.

# Result

| Before | After |
| ------- | ------ |
| ![image](https://github.com/y-c-wang/itsa-2023/assets/98584755/4b68cb5a-6c49-473b-b4aa-e18f91765a9c) | ![image](https://github.com/y-c-wang/itsa-2023/assets/98584755/ff6758cf-67c9-474d-8c88-91f6b8585b7d) |

# Remarks

Resolves #3 