### PR TITLE
fix: :bug: Set time zone to fit the time zone in Taiwan

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 document.addEventListener('DOMContentLoaded', () => {
-  fetch('https://api.open-meteo.com/v1/forecast?latitude=24.8&longitude=121.0&hourly=temperature_2m,relativehumidity_2m')
+  fetch('https://api.open-meteo.com/v1/forecast?latitude=24.8&longitude=121.0&hourly=temperature_2m,relativehumidity_2m&timezone=Asia%2FSingapore')
     .then(response => response.json())
     .then(data => {
       const temperatures = data.hourly.temperature_2m;


### PR DESCRIPTION
# Purpose

The original table has only `time` and `format`. This PR aims to add `humidity` to the table.

# Solution

- We modify the `params` of the api request to [Open-Meteo](https://open-meteo.com/) to specify the time zone to GMT+8, which is the time zone in Taiwan.

# Result

|                    | Before  | After                   |
| ------------ | -------- | ------------------ |
| Time Zone | GMT+0 | GMT+8 (Taiwan) |

# Remarks

Resolves #5 